### PR TITLE
Fixing add products validation image bug

### DIFF
--- a/src/schemas/ProductListingSchema.ts
+++ b/src/schemas/ProductListingSchema.ts
@@ -54,11 +54,22 @@ const ProductSpecTagSchema = z.tuple([
     z.string() // value
 ]);
 
-const ProductImageTagSchema = z.tuple([
-    z.literal("image"),
-    z.string().url(), // URL
-    z.string().optional(), // Optional dimensions
-    z.string().regex(/^\d+(\.\d+)?$/, "Must be a string-wrapped number").optional() // Optional sorting order
+const ProductImageTagSchema = z.union([
+    z.tuple([
+        z.literal("image"),
+        z.string().url()
+    ]),
+    z.tuple([
+        z.literal("image"),
+        z.string().url(),
+        z.string()
+    ]),
+    z.tuple([
+        z.literal("image"),
+        z.string().url(),
+        z.string(),
+        z.string().regex(/^\d+$/, "Must be an integer string (order)")
+    ])
 ]);
 
 const ProductWeightTagSchema = z.tuple([

--- a/src/utils/ProductListingUtils.ts
+++ b/src/utils/ProductListingUtils.ts
@@ -40,8 +40,8 @@ export const ProductListingUtils = {
             .filter(tag => tag[0] === 'image')
             .map(tag => ({
                 url: tag[1],
-                dimensions: tag[2],
-                order: tag[3] ? parseInt(tag[3], 10) : undefined
+                dimensions: tag.length >= 3 ? tag[2] : undefined,
+                order: tag.length >= 4 ? parseInt(tag[3] as string, 10) : undefined
             }))
             .sort((a, b) => {
                 if (a.order !== undefined && b.order !== undefined) {
@@ -178,10 +178,10 @@ export const ProductListingUtils = {
         // Images
         if (data.images) {
             data.images.forEach(image => {
-                const imageTag = ['image', image.url];
+                const imageTag: string[] = ['image', image.url];
                 if (image.dimensions) imageTag.push(image.dimensions);
                 if (image.order !== undefined) imageTag.push(image.order.toString());
-                tags.push(imageTag);
+                tags.push(imageTag.slice(0, 4)); // ✅ Ensure max 4 elements
             });
         }
 


### PR DESCRIPTION
🔧 Whats Changed
This PR fixes validation errors related to the image tag in the ProductListingSchema. Specifically, the ProductImageTagSchema was updated to use explicit z.union([...]) with specific tuple shapes instead of relying on z.string().optional() for optional fields like dimensions and order.

📌 Why
Zod's .optional() on a tuple element caused TypeScript and runtime inference issues:

z.tuple(["image", z.string().url(), z.string().optional()]) allowed unexpected extra arguments.

It also failed to correctly enforce or infer the tag length during validation (e.g., [ "image", "url", "extra" ] was invalid, but not clearly rejected).

✅ Fix
1.  Replaced it with a more strict and precise union of valid tag shapes:
`const ProductImageTagSchema = z.union([
  z.tuple(["image", z.string().url()]),
  z.tuple(["image", z.string().url(), z.string()]), // dimensions
  z.tuple(["image", z.string().url(), z.string(), z.string().regex(/^\d+$/, "Must be an integer string (order)")]) // dimensions + order
]);`
2. Slicing too many tags